### PR TITLE
docs: add project LLM Wiki

### DIFF
--- a/.llm-wiki/SCHEMA.md
+++ b/.llm-wiki/SCHEMA.md
@@ -1,0 +1,72 @@
+# Project LLM Wiki Schema
+
+## Domain
+
+`bling-bling` 볼링 동호회 점수 관리·통계 분석 웹 애플리케이션의 코드, 데이터 모델, OCR, 운영, 의사결정을 관리한다.
+
+## Storage Policy
+
+- `.llm-wiki/`는 에이전트가 관리하는 프로젝트 지식 원본이다.
+- `README.md`, `CLAUDE.md`, 소스 코드, 마이그레이션, 이슈·PR에서 확인한 사실을 raw source와 synthesis page로 정리한다.
+- 비밀값, 토큰, 실제 회원 개인정보, Supabase 키 값은 저장하지 않는다. 필요한 경우 구조와 마스킹된 식별자만 기록한다.
+- 공식 사용자 문서는 `README.md`와 `docs/`가 담당하고, `.llm-wiki/`는 개발·운영·의사결정의 누적 지식에 집중한다.
+
+## Page Types
+
+- `entity`: 프로젝트·서비스·외부 시스템
+- `concept`: 아키텍처·도메인·데이터 흐름·기술 개념
+- `decision`: 중요한 설계 결정
+- `incident`: 장애와 원인 분석
+- `runbook`: 반복 운영 절차
+- `query`: 재사용 가치가 있는 분석 결과
+- `summary`: 여러 자료의 종합 요약
+
+## Conventions
+
+- 파일명은 읽기 쉬운 kebab-case를 사용한다.
+- 모든 synthesis page는 YAML frontmatter를 사용한다.
+- 모든 신규·수정 페이지는 가능한 한 2개 이상의 상호 링크를 갖는다.
+- 코드 관련 사실에는 파일 경로와 확인 시점을 기록한다.
+- 확정된 사실과 추론·미확인 사항을 구분한다.
+- `index.md`와 `log.md`를 모든 변경에 맞춰 갱신한다.
+- raw source는 수정하지 않고 새 버전으로 추가한다.
+
+## Frontmatter
+
+```yaml
+---
+title: Page Title
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+type: entity | concept | decision | incident | runbook | query | summary
+tags: [project, architecture]
+sources: [raw/project-baseline.md]
+confidence: high | medium | low
+---
+```
+
+## Tag Taxonomy
+
+- `project`: 프로젝트 자체
+- `frontend`: React/Vite 프론트엔드
+- `typescript`: TypeScript 코드
+- `supabase`: Supabase/PostgreSQL/Storage/Realtime
+- `data-model`: 데이터 모델과 마이그레이션
+- `bowling-domain`: 볼링 도메인 규칙
+- `statistics`: 통계·랭킹·분석
+- `ocr`: 이미지 OCR과 전처리
+- `mcp`: MCP 서버·도구 통합
+- `deployment`: Vercel 및 배포
+- `security`: RLS·시크릿·보안
+- `testing`: 테스트·검증
+- `operations`: 운영 절차
+- `decision`: 설계 결정
+- `incident`: 장애 분석
+- `documentation`: 문서
+
+## Page Thresholds
+
+- 프로젝트 핵심 구조·도메인·데이터 흐름은 중앙 문서 하나만 있어도 페이지를 만든다.
+- 단순 파일 나열이나 일회성 메모는 raw에만 기록할 수 있다.
+- 페이지가 200줄을 넘으면 주제를 분리한다.
+- 같은 사실이 새 문서와 충돌하면 날짜와 출처를 함께 기록하고 조용히 덮어쓰지 않는다.

--- a/.llm-wiki/concepts/bling-bling-architecture.md
+++ b/.llm-wiki/concepts/bling-bling-architecture.md
@@ -1,0 +1,49 @@
+---
+title: Bling-Bling architecture
+created: 2026-08-09
+updated: 2026-08-09
+type: concept
+tags: [project, frontend, typescript, supabase, deployment]
+sources: [raw/project-baseline.md]
+confidence: medium
+---
+
+# Bling-Bling architecture
+
+## 구조
+
+```text
+React/Vite client
+  ├─ pages / components / hooks
+  ├─ services / utils / types
+  └─ React Query + Realtime
+        ↓
+Supabase
+  ├─ PostgreSQL: 회원·세션·점수·업로드 기록
+  ├─ Storage: 이미지 파일
+  ├─ RLS: 데이터 접근 제어
+  └─ Realtime: 대시보드 갱신
+        ↓
+Vercel deployment
+```
+
+## 코드 경계
+
+- `src/pages/`: 사용자 흐름과 화면
+- `src/components/`: 재사용 UI, 입력 폼, 차트
+- `src/hooks/`: 조회·변경·Realtime 연결
+- `src/services/`: Supabase 접근과 도메인 서비스
+- `src/utils/`: Excel 파싱·검증·오류 처리
+- `src/types/`: 볼링 및 DB 타입
+- `supabase/migrations/`: 스키마 변경의 기준
+
+## 설계상 핵심
+
+1. 서버 상태는 React Query로 캐시·갱신한다.
+2. 실시간 데이터 변경은 Supabase Realtime과 화면 쿼리 갱신을 연결한다.
+3. 회원·게임·점수 모델은 [[bowling-data-model]]을 기준으로 일관성을 유지한다.
+4. 이미지 인식은 기존 수동 입력을 대체하기보다 검토·수정 단계를 거치는 보조 입력으로 설계한다. 자세한 흐름은 [[ocr-score-recognition]]을 참조한다.
+
+## 확인 필요 사항
+
+README와 CLAUDE 문서는 일부 기능을 계획/완료로 설명하므로, 다음 변경 때 실제 `src/`와 `supabase/migrations/`를 기준으로 구현 상태를 갱신해야 한다.

--- a/.llm-wiki/concepts/bowling-data-model.md
+++ b/.llm-wiki/concepts/bowling-data-model.md
@@ -1,0 +1,47 @@
+---
+title: Bowling data model
+created: 2026-08-09
+updated: 2026-08-09
+type: concept
+tags: [project, bowling-domain, data-model, supabase, security]
+sources: [raw/project-baseline.md]
+confidence: medium
+---
+
+# Bowling data model
+
+## 핵심 엔티티
+
+| 엔티티 | 역할 |
+|---|---|
+| `members` | 동호회 회원과 가입 정보 |
+| `game_sessions` | 특정 날짜·장소의 게임 세션 |
+| `game_results` | 세션·회원·게임 번호별 점수 |
+| `upload_history` | 이미지 업로드와 처리 이력 |
+
+## 관계
+
+```text
+members 1 ── N game_results N ── 1 game_sessions
+                         ↑
+              upload_history (이미지 입력 이력)
+```
+
+실제 foreign key, nullable 여부, unique 제약, RLS 정책은 `supabase/migrations/`를 기준으로 확인해야 하며 이 페이지는 문서화된 개념 모델이다.
+
+## 도메인 규칙 후보
+
+- 한 세션은 여러 회원과 게임 결과를 가진다.
+- 일반 입력 흐름은 최대 3게임 점수 기록을 전제로 한다.
+- 회원별 평균·최고·최저·추세 통계는 `game_results`에서 계산된다.
+- OCR 또는 Excel 입력은 저장 전에 이름 매칭과 점수 검증을 거쳐야 한다.
+
+## 보안 경계
+
+실제 회원 식별정보와 Supabase 인증/키 값은 Wiki에 기록하지 않는다. 데이터 접근은 Supabase RLS 정책과 애플리케이션의 권한 검사를 함께 확인해야 한다.
+
+## 관련 페이지
+
+- [[bling-bling]]
+- [[bling-bling-architecture]]
+- [[ocr-score-recognition]]

--- a/.llm-wiki/concepts/ocr-score-recognition.md
+++ b/.llm-wiki/concepts/ocr-score-recognition.md
@@ -1,0 +1,45 @@
+---
+title: OCR score recognition
+created: 2026-08-09
+updated: 2026-08-09
+type: concept
+tags: [project, ocr, bowling-domain, frontend]
+sources: [raw/project-baseline.md]
+confidence: low
+---
+
+# OCR score recognition
+
+## 목적
+
+볼링 화이트보드 사진에서 회원 이름과 점수를 자동 인식해 입력 부담을 낮추는 기능이다. 문서 기준으로는 Tesseract.js와 Canvas API 기반의 계획 또는 진행 중 기능이다.
+
+## 권장 처리 흐름
+
+```text
+사진 업로드
+  → Canvas 이미지 전처리
+  → Tesseract.js OCR
+  → 이름·점수 후보 파싱
+  → 회원 매칭 및 점수 범위 검증
+  → 사용자 검토·수정
+  → game_sessions / game_results 저장
+  → upload_history 기록
+```
+
+## 설계 원칙
+
+- OCR 결과를 즉시 확정하지 않고 사용자가 검토한다.
+- 원본 이미지는 Storage에 보관하되 접근 정책과 보존 기간을 명확히 한다.
+- 인식 실패·수정 이력을 추적할 수 있도록 업로드 처리 상태를 남긴다.
+- 이름 매칭 실패와 점수 파싱 실패를 별도 오류로 표시한다.
+
+## 현재 불확실성
+
+실제 OCR 구현 여부, 전처리 파라미터, 저장 스키마는 소스 코드와 Supabase migration을 추가 점검해야 한다. 현재 페이지는 제품 문서에 기반한 설계 지식이며 구현 완료를 의미하지 않는다.
+
+## 관련 페이지
+
+- [[bling-bling]]
+- [[bling-bling-architecture]]
+- [[bowling-data-model]]

--- a/.llm-wiki/entities/bling-bling.md
+++ b/.llm-wiki/entities/bling-bling.md
@@ -1,0 +1,36 @@
+---
+title: Bling-Bling
+created: 2026-08-09
+updated: 2026-08-09
+type: entity
+tags: [project, frontend, bowling-domain, statistics]
+sources: [raw/project-baseline.md]
+confidence: medium
+---
+
+# Bling-Bling
+
+## 개요
+
+`bling-bling`은 볼링 동호회의 회원·게임·점수 기록을 관리하고 통계를 제공하는 React 기반 웹 애플리케이션이다. 초기 제품 방향은 화이트보드 사진을 OCR로 읽어 수동 입력을 줄이는 것이다.
+
+## 현재 기술 경계
+
+- 프론트엔드: React 18 + TypeScript + Vite + TailwindCSS
+- 데이터/백엔드: Supabase PostgreSQL, Storage, Realtime, RLS
+- 배포: Vercel 설정 포함
+- 개발 보조: Context7 MCP, ESLint, Vitest
+
+## 주요 도메인 기능
+
+- 회원 등록·조회·수정 및 티어 계산
+- 게임 세션과 3게임 점수 입력
+- 개인·그룹·재미있는 통계
+- Excel 데이터 가져오기와 Supabase 저장
+- 향후 이미지 OCR 기반 점수 인식
+
+## 관련 페이지
+
+- [[bling-bling-architecture]]
+- [[bowling-data-model]]
+- [[ocr-score-recognition]]

--- a/.llm-wiki/index.md
+++ b/.llm-wiki/index.md
@@ -1,0 +1,26 @@
+# Bling-Bling Project Wiki Index
+
+> `bling-bling` 프로젝트의 에이전트 관리 지식 카탈로그.
+> Last updated: 2026-08-09 | Total pages: 4
+
+## Entities
+
+- [[bling-bling]] — 볼링 화이트보드 점수 관리, OCR, 통계 분석을 제공하는 React 기반 웹 애플리케이션.
+
+## Concepts
+
+- [[bling-bling-architecture]] — React/Vite 프론트엔드와 Supabase 백엔드의 현재 구성 및 주요 데이터 흐름.
+- [[bowling-data-model]] — 회원·게임 세션·게임 결과·업로드 기록을 중심으로 한 볼링 데이터 모델.
+- [[ocr-score-recognition]] — 계획된 이미지 전처리·Tesseract.js OCR 및 검증 흐름.
+
+## Decisions
+
+## Incidents
+
+## Runbooks
+
+## Queries
+
+## Raw Sources
+
+- `raw/project-baseline.md` — 2026-08-09 기준 README/CLAUDE 및 저장소 구조에서 추출한 초기 기준선.

--- a/.llm-wiki/log.md
+++ b/.llm-wiki/log.md
@@ -1,0 +1,12 @@
+# Bling-Bling Project Wiki Log
+
+> Chronological record of project-wiki actions. Append-only.
+> Format: `## [YYYY-MM-DD] action | subject`
+
+## [2026-08-09] create | Project LLM Wiki initialized
+
+- Repository: `quenya/bling-bling`
+- Path: `/Volumes/Seagate500/project/js/bling-bling`
+- Created `SCHEMA.md`, `index.md`, `log.md`
+- Created initial baseline raw source and four synthesis pages
+- Existing working-tree changes were preserved; no existing project files were modified

--- a/.llm-wiki/raw/project-baseline.md
+++ b/.llm-wiki/raw/project-baseline.md
@@ -1,0 +1,34 @@
+---
+title: Bling-Bling project baseline
+ingested: 2026-08-09
+source_url: local://bling-bling/README.md-and-CLAUDE.md
+kind: project-baseline
+---
+
+# Bling-Bling project baseline
+
+이 raw source는 2026-08-09에 저장소의 `README.md`, `CLAUDE.md`, 최상위 구조를 확인해 만든 초기 기준선이다. 원문 문서는 저장소 루트에 유지하며, 이 파일은 Wiki의 초기 provenance용 요약 원본이다.
+
+## 확인된 목적
+
+볼링 동호회 화이트보드 사진에서 점수를 관리하고, 회원·게임 기록을 바탕으로 통계를 분석하는 웹 애플리케이션이다.
+
+## 확인된 기술
+
+- React 18, TypeScript, Vite, TailwindCSS
+- React Router, React Hook Form, TanStack React Query
+- Chart.js / react-chartjs-2
+- Supabase PostgreSQL, Storage, Realtime, RLS
+- Vitest, ESLint, Context7 MCP
+- Vercel 배포 설정
+
+## 확인된 기능 상태
+
+- 수동 게임 입력, 회원 관리, 통계 대시보드, 데이터 가져오기 및 Supabase 연동은 구현된 기능으로 문서화되어 있다.
+- OCR 기능과 일부 고급 통계 기능은 계획 또는 진행 중으로 문서화되어 있다.
+- `src/`, `supabase/`, `scripts/`, `sheets/`, `images/`가 주요 작업 영역이다.
+
+## 주의
+
+- 문서의 “현재 상태” 날짜와 실제 코드 상태가 다를 수 있으므로, 구현 여부를 단정할 때는 소스 코드와 마이그레이션을 다시 확인한다.
+- 환경변수 값, Supabase 키, 실제 회원정보는 이 Wiki에 저장하지 않는다.


### PR DESCRIPTION
## Summary
- Add a project-local `.llm-wiki/` knowledge base for Bling-Bling
- Document the project architecture, bowling data model, and OCR score-recognition flow
- Add schema, index, raw baseline, and append-only log

## Verification
- `git diff --check origin/master...HEAD`
- Wiki frontmatter and internal links validated locally
- No secrets or credentials included

## Scope
- This PR contains only the new `.llm-wiki/` directory.
- Existing unrelated working-tree changes were intentionally excluded.
