### PR TITLE
docs: official Sheet as bowling result source of truth

### DIFF
--- a/.llm-wiki/concepts/ocr-score-recognition.md
+++ b/.llm-wiki/concepts/ocr-score-recognition.md
@@ -4,7 +4,7 @@ created: 2026-08-09
 updated: 2026-08-09
 type: concept
 tags: [project, ocr, bowling-domain, frontend]
-sources: [raw/project-baseline.md]
+sources: [raw/project-baseline.md, raw/2026-08-09-official-sheet-decision.md]
 confidence: low
 ---
 
@@ -12,19 +12,18 @@ confidence: low
 
 ## 목적
 
-볼링 화이트보드 사진에서 회원 이름과 점수를 자동 인식해 입력 부담을 낮추는 기능이다. 문서 기준으로는 Tesseract.js와 Canvas API 기반의 계획 또는 진행 중 기능이다.
+볼링 화이트보드 사진에서 회원 이름과 점수를 자동 인식해 입력 부담을 낮추는 기능 후보였다. 2026-08-09 결정에 따라 현재는 운영 등록 경로로 사용하지 않으며, 공식 결과 Sheet를 기준 데이터로 삼는다.
 
 ## 권장 처리 흐름
 
 ```text
-사진 업로드
+사진 확보 (비공개 보관)
   → Canvas 이미지 전처리
   → Tesseract.js OCR
   → 이름·점수 후보 파싱
   → 회원 매칭 및 점수 범위 검증
-  → 사용자 검토·수정
-  → game_sessions / game_results 저장
-  → upload_history 기록
+  → 사용자 검토·수정 (현재 미진행)
+  → 별도 재검토
 ```
 
 ## 설계 원칙
@@ -36,10 +35,11 @@ confidence: low
 
 ## 현재 불확실성
 
-실제 OCR 구현 여부, 전처리 파라미터, 저장 스키마는 소스 코드와 Supabase migration을 추가 점검해야 한다. 현재 페이지는 제품 문서에 기반한 설계 지식이며 구현 완료를 의미하지 않는다.
+OCR 엔진·전처리 실험은 신뢰성과 개인정보 보호 우려로 중단했다. 공식 Sheet가 현재의 source of truth이며, OCR 자동화는 정확도·실패 패턴·비식별화·보존 정책을 포함한 별도 재검토 사항이다.
 
 ## 관련 페이지
 
 - [[bling-bling]]
 - [[bling-bling-architecture]]
 - [[bowling-data-model]]
+- [[official-sheet-as-source-of-truth]]

--- a/.llm-wiki/decisions/official-sheet-as-source-of-truth.md
+++ b/.llm-wiki/decisions/official-sheet-as-source-of-truth.md
@@ -1,0 +1,32 @@
+---
+title: Official Sheet as Result Source of Truth
+created: 2026-08-09
+updated: 2026-08-09
+type: decision
+tags: [project, bowling-domain, ocr, security, decision]
+sources: [raw/2026-08-09-official-sheet-decision.md]
+confidence: high
+---
+
+# Official Sheet as Result Source of Truth
+
+## Decision
+
+Bling-Bling 경기 결과 등록은 **공식 결과 Sheet를 기준 데이터(source of truth)**로 사용한다. 경기 결과 이미지의 OCR 자동 인식은 현재 신뢰성과 개인정보 보호 측면의 불확실성이 있어 운영 등록 경로로 사용하지 않는다.
+
+## Consequences
+
+- 공식 Sheet를 확인·정리한 뒤 수동 또는 검증된 import 절차로 `game_sessions`와 `game_results`에 반영한다.
+- 원본 경기 결과 이미지는 공개 GitHub 저장소와 공개 Issue에 올리지 않고 외장하드의 비공개 경로에 보관한다.
+- OCR 관련 Issue #3, #4, #5, #11은 모두 `not planned`로 종료했다.
+- OCR 자동화는 별도 재검토 사항이며, 재개할 경우 정확도·실패 패턴·비식별화·보존 정책을 먼저 검증한다.
+
+## Related
+
+- [[ocr-score-recognition]]
+- [[bowling-data-model]]
+- [[bling-bling]]
+
+## Evidence
+
+- GitHub Issue #11 및 종료 댓글: [raw/2026-08-09-official-sheet-decision.md]

--- a/.llm-wiki/index.md
+++ b/.llm-wiki/index.md
@@ -1,7 +1,7 @@
 # Bling-Bling Project Wiki Index
 
 > `bling-bling` 프로젝트의 에이전트 관리 지식 카탈로그.
-> Last updated: 2026-08-09 | Total pages: 4
+> Last updated: 2026-08-09 | Total pages: 5
 
 ## Entities
 
@@ -11,9 +11,10 @@
 
 - [[bling-bling-architecture]] — React/Vite 프론트엔드와 Supabase 백엔드의 현재 구성 및 주요 데이터 흐름.
 - [[bowling-data-model]] — 회원·게임 세션·게임 결과·업로드 기록을 중심으로 한 볼링 데이터 모델.
-- [[ocr-score-recognition]] — 계획된 이미지 전처리·Tesseract.js OCR 및 검증 흐름.
+- [[ocr-score-recognition]] — 중단된 OCR 후보와 공식 Sheet 기준 전환 상태.
 
 ## Decisions
+- [[official-sheet-as-source-of-truth]] — 공식 결과 Sheet를 경기 결과 등록의 source of truth로 사용하는 결정.
 
 ## Incidents
 

--- a/.llm-wiki/log.md
+++ b/.llm-wiki/log.md
@@ -10,3 +10,18 @@
 - Created `SCHEMA.md`, `index.md`, `log.md`
 - Created initial baseline raw source and four synthesis pages
 - Existing working-tree changes were preserved; no existing project files were modified
+
+## [2026-08-09] decision | Official Sheet as result source of truth
+
+- Closed GitHub Issue #11 as `not planned` after deciding OCR is not reliable enough for result registration.
+- Kept original match images in private external-disk storage; no public repository or Issue upload.
+- Created decision page: `decisions/official-sheet-as-source-of-truth.md`
+- Updated concept page: `concepts/ocr-score-recognition.md`
+- Added immutable raw source: `raw/2026-08-09-official-sheet-decision.md`
+- Official result Sheets are now the source of truth for `game_sessions` and `game_results` registration.
+
+## [2026-08-09] decision | Close OCR implementation issues
+
+- Closed Issues #3, #4, and #5 as `not planned`.
+- Their image-upload, OCR-engine, and OCR-review/database-save scopes are superseded by the official-Sheet source-of-truth decision.
+- Added the closure rationale to each issue without storing private match images in GitHub.

--- a/.llm-wiki/raw/2026-08-09-official-sheet-decision.md
+++ b/.llm-wiki/raw/2026-08-09-official-sheet-decision.md
@@ -1,0 +1,14 @@
+---
+source_url: https://github.com/quenya/bling-bling/issues/11#issuecomment-5231587159
+ingested: 2026-08-09
+sha256: ec3dc6887fc596a3fedb70e9197188d4d0b4122ad1136dfd5f7eb6d0ed0f8117
+---
+
+# Official Sheet source-of-truth decision
+
+- OCR recognition was judged insufficiently reliable for production registration.
+- Official result Sheets are the source of truth for bowling-result registration.
+- Original match images remain in private external-disk storage and are not stored in the public repository or public Issue.
+- OCR engine and preprocessing experiments are stopped for now.
+- Issue #11 was closed as `not planned`.
+- Future automation can be reconsidered as a separate decision after a reliable privacy-preserving approach is available.


### PR DESCRIPTION
## Summary
- Record the decision to use official result Sheets as the source of truth.
- Document why OCR automation is stopped and keep original match images private.
- Record closure of OCR Issues #3, #4, #5, and #11.

## Validation
- Verified project Wiki raw-source SHA-256.
- Checked Wiki index, frontmatter, and append-only log updates.

## Related
- Closes #3
- Closes #4
- Closes #5
- Closes #11
